### PR TITLE
Fixed conflicting  CLI flags

### DIFF
--- a/pocket_to_sqlite/cli.py
+++ b/pocket_to_sqlite/cli.py
@@ -74,7 +74,7 @@ def auth(auth):
     default="auth.json",
     help="Path to auth tokens, defaults to auth.json",
 )
-@click.option("-a", "--all", is_flag=True, help="Fetch all items (not just new ones)")
+@click.option("--all", is_flag=True, help="Fetch all items (not just new ones)")
 @click.option("-s", "--silent", is_flag=True, help="Don't show progress bar")
 def fetch(db_path, auth, all, silent):
     "Save Pocket data to a SQLite database"


### PR DESCRIPTION
The `-a` used for the auth credentials and the shortened form of the `--all` flags were in conflict on the `fetch` command. To be consistent with other `-to-sqlite` libraries in the Dogsheep ecosystem, I removed the shortened form of the `--all` flag.